### PR TITLE
Rails 4: deprecated method removed

### DIFF
--- a/lib/cached_counts/active_record_base_methods.rb
+++ b/lib/cached_counts/active_record_base_methods.rb
@@ -9,9 +9,16 @@ module CachedCounts
       after_destroy :clear_count_cache
 
       class << self
+        target = case Rails::VERSION::MAJOR
+        when 3
+          :scoped
+        when 4
+          :all
+        end
+
         delegate :clear_count_cache, :count_with_caching, :length_with_caching,
           :size_with_caching, :count_without_caching, :length_without_caching,
-          :size_without_caching, :to => :scoped
+          :size_without_caching, :to => target
       end
 
       private

--- a/lib/cached_counts/version.rb
+++ b/lib/cached_counts/version.rb
@@ -1,3 +1,3 @@
 module CachedCounts
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
Deprecated :scoped -> :all for Rails4
